### PR TITLE
#2 Set the personality of the chatbot

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -9,3 +9,4 @@ InsertPack=(PackSource="StarterContent.upack",PackName="StarterContent")
 
 [/Script/Vivian.ApiClient]
 ApiKey=Put your OpenAI Api Key here
+BaseConversationContext=You are a chatbot that assists elderly people with early signs of dementia by acting like a companion for them, so that they feel less alone. These people speak only Dutch, so you should respond in Dutch. Your own name is Vivian

--- a/Source/Vivian/Private/ApiClient.cpp
+++ b/Source/Vivian/Private/ApiClient.cpp
@@ -44,8 +44,15 @@ void UApiClient::MakeAPIRequest()
 
     // Create a new JSON array for the "messages" key-value pair
     TArray<TSharedPtr<FJsonValue>> MessagesArray;
-    TSharedPtr<FJsonObject> MessageObject = MakeShareable(new FJsonObject);
 
+    // Message object with the base conversation context
+    TSharedPtr<FJsonObject> BaseConversationContextMessageObject = MakeShareable(new FJsonObject);
+    BaseConversationContextMessageObject->SetStringField("role", "system");
+    BaseConversationContextMessageObject->SetStringField("content", BaseConversationContext);
+    MessagesArray.Add(MakeShareable(new FJsonValueObject(BaseConversationContextMessageObject)));
+
+    // Message object with the user input
+    TSharedPtr<FJsonObject> MessageObject = MakeShareable(new FJsonObject);
     MessageObject->SetStringField("role", "user");
     MessageObject->SetStringField("content", InputText);
     MessagesArray.Add(MakeShareable(new FJsonValueObject(MessageObject)));

--- a/Source/Vivian/Public/ApiClient.h
+++ b/Source/Vivian/Public/ApiClient.h
@@ -39,4 +39,6 @@ private:
     // Read the API key from the config file
     UPROPERTY(VisibleAnywhere, Config)
         FString ApiKey;
+    UPROPERTY(VisibleAnywhere, Config)
+        FString BaseConversationContext;
 };


### PR DESCRIPTION
Issue: #2 
Used the config file to set the context of the chatbot, so that it's separated from the rest of the code. The API key can also be set here but I now set it in the Unreal application itself, so that it is safe from being pushed to the internet. 
The context itself may be edited later if it turns out to be off, but for now I don't want to spend more time on this.

[Documentation that I used](https://www.makeuseof.com/chatgpt-api-complete-guide/)

![image](https://user-images.githubusercontent.com/43112975/236155620-b83b34e3-0a33-4ce3-9aa8-e69bfbc730f1.png)
